### PR TITLE
Immortal mode + refactoring

### DIFF
--- a/A-4E-C/ExternalFM/FM/Airframe.h
+++ b/A-4E-C/ExternalFM/FM/Airframe.h
@@ -383,8 +383,19 @@ public:
 		setDamageDelta( Airframe::Damage::WING_L_OUT, 1.0 );
 		setDamageDelta( Airframe::Damage::AILERON_L, 1.0 );
 	}
+	inline void setNoDamage(bool state)
+	{
+		m_noDamage = state;
+	}
+	inline bool getNoDamage()
+	{
+		return m_noDamage;
+	}
 
 private:
+
+	//No damage mode
+	bool m_noDamage = false;
 
 	//Airframe Constants
 	const double m_hookExtendTime = 1.5;

--- a/A-4E-C/ExternalFM/FM/FuelSystem2.cpp
+++ b/A-4E-C/ExternalFM/FM/FuelSystem2.cpp
@@ -54,18 +54,24 @@ bool FuelSystem2::handleInput( int command, float value )
 
 		return true;
 	case DEVICE_COMMANDS_ENGINE_DROP_TANKS_SW:
-		m_externalTankPressure = true;
-		m_externalTankFlightRefuel = false;
 
-		if ( value == 1.0 )
-			m_externalTankPressure = false;
-		else if ( value == -1.0 )
+		if ( value == 1.0 ) // Off
 		{
-			m_externalTankFlightRefuel = true;
 			m_externalTankPressure = false;
+			m_externalTankFlightRefuel = false;
 		}
-
+		else if ( value == -1.0 ) // Flight refuel
+		{
+			m_externalTankPressure = false;
+			m_externalTankFlightRefuel = true;
+		}
+		else // Press
+		{
+			m_externalTankPressure = true;
+			m_externalTankFlightRefuel = false;
+		}
 		return true;
+		
 	case DEVICE_COMMANDS_FUEL_TRANSFER_BYPASS:
 		if ( value == 1.0 )
 			m_wingTankBypass = true;
@@ -86,7 +92,8 @@ void FuelSystem2::addFuel( double dm, bool wingFirst )
 	if ( dm > 0.0 && ! wingFirst )
 		dm = addFuelToTank( TANK_FUSELAGE, dm );
 
-	printf( "dm after fuse: %lf\n", dm );
+	//printf( "dm after fuse: %lf\n", dm );
+	
 	//If the wing tank bypass switch is enabled we
 	//refuel the external tanks instead.
 	if ( m_externalTankFlightRefuel )
@@ -97,11 +104,9 @@ void FuelSystem2::addFuel( double dm, bool wingFirst )
 			externalTanks += m_fuelCapacity[i] > 15.0;
 		}
 
-		double fracDM = dm / (double)externalTanks;
-
-
 		if ( externalTanks > 0 )
 		{
+			double fracDM = dm / (double)externalTanks;
 			dm = 0.0;
 
 			for ( int i = TANK_EXTERNAL_LEFT; i < NUMBER_OF_TANKS; i++ )
@@ -112,25 +117,25 @@ void FuelSystem2::addFuel( double dm, bool wingFirst )
 		}
 	}
 
-	printf( "dm after ext: %lf\n", dm );
+	//printf( "dm after ext: %lf\n", dm );
 	
 	if ( ! m_wingTankBypass ) //Bypass is not enabled so refuel the wing tank.
 	{
 		dm = addFuelToTank( TANK_WING, dm );
 	}
 
-	printf( "dm after wing: %lf\n", dm );
+	//printf( "dm after wing: %lf\n", dm );
 
 	//If removing fuel remove it from the wing tanks first.
 	if ( dm < 0.0 || wingFirst )
 		dm = addFuelToTank( TANK_FUSELAGE, dm );
 
-	printf( "dm after fuse/all: %lf\n", dm );
+	//printf( "dm after fuse/all: %lf\n", dm );
 }
 
 void FuelSystem2::update( double dt )
 {
-	if(m_unlimited_fuel)
+	if(m_unlimitedFuel)
 	{
 		m_boostPumpPressure = true; //Cut the Fuel Boost light
 		return;

--- a/A-4E-C/ExternalFM/FM/FuelSystem2.h
+++ b/A-4E-C/ExternalFM/FM/FuelSystem2.h
@@ -81,7 +81,7 @@ public:
 	inline void setTankPos( Tank tank, const Vec3& pos ) { m_fuelPos[tank] = pos; }
 
 private:
-	bool m_unlimited_fuel = false;
+	bool m_unlimitedFuel = false;
 
 	double m_fuel[NUMBER_OF_TANKS] = { 0.0, 0.0, 0.0, 0.0, 0.0 };
 	double m_fuelPrevious[NUMBER_OF_TANKS] = { 0.0, 0.0, 0.0, 0.0, 0.0 };
@@ -115,7 +115,7 @@ private:
 
 void FuelSystem2::setUnlimitedFuel( bool state )
 {
-	m_unlimited_fuel = state;
+	m_unlimitedFuel = state;
 }
 
 void FuelSystem2::setBoostPumpPower( bool power )

--- a/A-4E-C/ExternalFM/FM/Scooter.cpp
+++ b/A-4E-C/ExternalFM/FM/Scooter.cpp
@@ -609,7 +609,9 @@ void ed_fm_set_current_state_body_axis
 
 void ed_fm_on_damage( int element, double element_integrity_factor )
 {
-	s_airframe->setIntegrityElement((Scooter::Airframe::Damage)element, (float)element_integrity_factor);
+	if (s_airframe->getNoDamage() == false){
+		s_airframe->setIntegrityElement((Scooter::Airframe::Damage)element, (float)element_integrity_factor);
+	}
 }
 
 void ed_fm_set_surface
@@ -1259,8 +1261,7 @@ bool ed_fm_LERX_vortex_update( unsigned idx, LERX_vortex& out )
 
 void ed_fm_set_immortal( bool value )
 {
-	if ( value )
-		printf( "Nice try!\n" );
+	s_airframe->setNoDamage(value);
 }
 
 void ed_fm_unlimited_fuel( bool value )


### PR DESCRIPTION
Four changes:

- immortal mode implemented by bypassing `ed_fm_on_damage` if activated
- unlimited fuel name convention correction
- refactoring of drop tank switch logic to be more clear, no behavior change, only explicitly setting the three variables inside the cases
- put `fracDM` inside the if so it could avoid division by 0, as it is only used inside the if block.