### PR TITLE
Enable server-side version checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
           mkdir -p Community_A-4E-C_${{ env.RELEASE_VERSION }}/Mods/aircraft/
           python get_binaries.py
           cp -R A-4E-C Community_A-4E-C_${{ env.RELEASE_VERSION }}/Mods/aircraft/A-4E-C
+          cp -R Scripts Community_A-4E-C_${{ env.RELEASE_VERSION }}
           cp README.md Community_A-4E-C_${{ env.RELEASE_VERSION }}/README.md
           cp CHANGELOG.md "Community_A-4E-C_${{ env.RELEASE_VERSION }}/CHANGELOG ${{ env.RELEASE_VERSION }}.md"
           cd Community_A-4E-C_${{ env.RELEASE_VERSION }}

--- a/Scripts/Hooks/A4EHook.lua
+++ b/Scripts/Hooks/A4EHook.lua
@@ -1,0 +1,96 @@
+-- A4EHook.lua
+-- Purpose:
+--   Enforces A-4E-C mod version compatibility on multiplayer servers/clients for DCS.
+--   Clients report their local A-4E-C plugin version to the server via RPC.
+--   The server stores versions per-player and prevents slot changes to A-4E-C if versions mismatch.
+--
+-- Key concepts:
+--   - Client: sends its A-4E-C version to the server upon connect.
+--   - Server: records each player's version and validates when players try to take an A-4E-C slot.
+--   - RPC: simple remote procedure call mechanism used to send versions to the server.
+--
+-- by Special K
+
+local base		    = _G
+local RPC   	    = base.require('RPC')
+local a4e_hook 	    = a4e_hook or {}
+local a4e_versions  = {}
+
+-- Returns the plugin descriptor for the A-4E-C mod from the global plugin list.
+-- Output:
+--   table or nil: plugin object with fields shortName, version, etc.
+function get_plugin()
+	for _, plugin in pairs(base.plugins) do
+		if plugin.shortName == 'A-4E-C' then
+			return plugin
+		end
+	end
+end
+
+-- Client-side callback: invoked when the player connects.
+-- Behavior:
+--   - No-op on server (server doesn't need to register itself this way).
+--   - On client, finds the local A-4E-C plugin and RPCs its version to the server.
+function a4e_hook.onPlayerConnect()
+	if Sim.isServer() then
+		return
+	end
+	plugin = get_plugin()
+	if not plugin then
+	    return
+	end
+    log.write('A4EHook', log.DEBUG, "Version: " .. plugin.version)
+	-- Use pcall to avoid hard failure if RPC fails (e.g., race or connectivity issue).
+	pcall(RPC.sendEvent, net.get_server_id() , "registerA4EVersion", plugin.version)
+end
+
+-- Server-side callback: triggered when a player attempts to change to a slot.
+-- Params:
+--   id (number): player id
+--   side (number): coalition/side index (unused here)
+--   slot (string): unit name/type reference for the slot
+-- Behavior:
+--   - If the target slot is an A-4E-C aircraft, ensure the player's reported version
+--     matches the server's a4e_hook.myversion. If not, deny the slot change.
+-- Return:
+--   false to deny the slot change; nil to allow normal processing.
+function a4e_hook.onPlayerTryChangeSlot(id, side, slot)
+	log.write('A4EHook', log.DEBUG, "onPlayerTryChangeSlot()")
+	if DCS.getUnitTypeAttribute(DCS.getUnitType(slot), "DisplayName") == 'A-4E-C' then
+		if a4e_versions[id] ~= a4e_hook.myversion then
+			net.send_chat_to("You need to use A-4E-C version " .. a4e_hook.myversion .. " to join this slot.", id)
+			return false
+		else
+			log.write('A4EHook', log.DEBUG, "Version matches, player is allowed to join this slot.")
+		end
+	end
+end
+
+-- Server-side callback: resets a player's reported A-4E-C version.
+-- Params:
+--   id (number): player id (sender)
+function a4e_hook.onPlayerDisconnect(id, err_code)
+    a4e_versions[id] = nil
+end
+
+-- RPC endpoint on the server: records a player's reported A-4E-C version.
+-- Params:
+--   id (number): player id (sender)
+--   version (string): player's local A-4E-C plugin version
+function RPC.method.registerA4EVersion(id, version)
+	log.write('A4EHook', log.DEBUG, 'Registering id=' .. id .. ', version=' .. version)
+	a4e_versions[id] = version
+end
+
+-- Register our callbacks with DCS so onPlayerConnect/onPlayerTryChangeSlot are invoked.
+DCS.setUserCallbacks(a4e_hook)
+
+-- Server-only initialization: capture server's A-4E-C version for comparison.
+if Sim.isServer() then
+	plugin = get_plugin()
+	if plugin then
+        a4e_hook.myversion = plugin.version
+    else
+    	log.write('A4EHook', log.ERROR, 'A-4E-C not installed correctly!')
+    end
+end

--- a/Scripts/Hooks/A4EHook.lua
+++ b/Scripts/Hooks/A4EHook.lua
@@ -32,7 +32,7 @@ end
 --   - No-op on server (server doesn't need to register itself this way).
 --   - On client, finds the local A-4E-C plugin and RPCs its version to the server.
 function a4e_hook.onPlayerConnect()
-	if Sim.isServer() then
+	if DCS.isServer() then
 		return
 	end
 	plugin = get_plugin()
@@ -86,7 +86,7 @@ end
 DCS.setUserCallbacks(a4e_hook)
 
 -- Server-only initialization: capture server's A-4E-C version for comparison.
-if Sim.isServer() then
+if DCS.isServer() then
 	plugin = get_plugin()
 	if plugin then
         a4e_hook.myversion = plugin.version

--- a/Scripts/Hooks/A4EHook.lua
+++ b/Scripts/Hooks/A4EHook.lua
@@ -16,6 +16,10 @@ local RPC   	    = base.require('RPC')
 local a4e_hook 	    = a4e_hook or {}
 local a4e_versions  = {}
 
+if not DCS.isServer() then
+    local MsgWindow	= require('MsgWindow')
+end
+
 -- Returns the plugin descriptor for the A-4E-C mod from the global plugin list.
 -- Output:
 --   table or nil: plugin object with fields shortName, version, etc.
@@ -41,7 +45,7 @@ function a4e_hook.onPlayerConnect()
 	end
     log.write('A4EHook', log.DEBUG, "Version: " .. plugin.version)
 	-- Use pcall to avoid hard failure if RPC fails (e.g., race or connectivity issue).
-	pcall(RPC.sendEvent, net.get_server_id() , "registerA4EVersion", plugin.version)
+	pcall(RPC.sendEvent, net.get_server_id() , "a4e_register_version", plugin.version)
 end
 
 -- Server-side callback: triggered when a player attempts to change to a slot.
@@ -58,7 +62,8 @@ function a4e_hook.onPlayerTryChangeSlot(id, side, slot)
 	log.write('A4EHook', log.DEBUG, "onPlayerTryChangeSlot()")
 	if DCS.getUnitTypeAttribute(DCS.getUnitType(slot), "DisplayName") == 'A-4E-C' then
 		if a4e_versions[id] ~= a4e_hook.myversion then
-			net.send_chat_to("You need to use A-4E-C version " .. a4e_hook.myversion .. " to join this slot.", id)
+		    message = "You need to use A-4E-C version " .. a4e_hook.myversion .. " to join this slot."
+        	pcall(RPC.sendEvent, id , "a4e_deny_version", message)
 			return false
 		else
 			log.write('A4EHook', log.DEBUG, "Version matches, player is allowed to join this slot.")
@@ -77,13 +82,36 @@ end
 -- Params:
 --   id (number): player id (sender)
 --   version (string): player's local A-4E-C plugin version
-function RPC.method.registerA4EVersion(id, version)
+function RPC.method.a4e_register_version(id, version)
+    if DCS.isTrackPlaying() == true then
+        return
+    end
+
 	log.write('A4EHook', log.DEBUG, 'Registering id=' .. id .. ', version=' .. version)
 	a4e_versions[id] = version
 end
 
+-- RPC endpoint on the client: sends a GUI message.
+-- Params:
+--   id (number): server id
+--   message (string): message to display
+function RPC.method.a4e_deny_version(server_id, message)
+    if DCS.isTrackPlaying() == true then
+        return
+    end
+
+	log.write('A4EHook', log.DEBUG, 'wrongA4EVersionMessage()')
+    if DCS.isServer() then
+        return
+    end
+    local handler = MsgWindow.info(message, "A-4E-C version mismatch detected", "OK")
+    handler:show()
+end
+
 -- Register our callbacks with DCS so onPlayerConnect/onPlayerTryChangeSlot are invoked.
-DCS.setUserCallbacks(a4e_hook)
+if DCS.isTrackPlaying() == false then
+    DCS.setUserCallbacks(a4e_hook)
+end
 
 -- Server-only initialization: capture server's A-4E-C version for comparison.
 if DCS.isServer() then


### PR DESCRIPTION
In the past we had issues when clients used different versions of the A4, especially with Tacview.
This little Hook script, which will run on the client and the server (that has the A4 mod installed) will enable a version check and deny the slot to players, if the version mismatches.

I have amended the build script, but I am not 100% sure if it works, so you guys might want to have a look if that was all that was needed to include the Scripts/Hooks directory into the mod.